### PR TITLE
Depth uses transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Crate providing simple 2D parallax layers in Bevy.
 
-## Features
+## In this crate:
 * **`ParallaxPlugin`** - Plugin required for the parallax functionality.
 * **`ParallaxCamera`** - Component for marking the parallax camera.
 * **`ParallaxLayer`** - Component for creating a parallax layer.

--- a/src/components.rs
+++ b/src/components.rs
@@ -56,7 +56,7 @@ pub struct ParallaxCamera;
 ///     commands.spawn_batch(layers);
 /// }
 /// ```
-/// 
+///
 /// ## Note
 /// It is not necessary to provide a `TransformBundle` to the parallax layer but if you do,
 /// the initialisation process only takes into account the z-value as a depth offset without

--- a/src/components.rs
+++ b/src/components.rs
@@ -56,6 +56,11 @@ pub struct ParallaxCamera;
 ///     commands.spawn_batch(layers);
 /// }
 /// ```
+/// 
+/// ## Note
+/// It is not necessary to provide a `TransformBundle` to the parallax layer and if you do,
+/// the initialisation process only takes into account the z-value as a depth offset without
+/// affecting the depth factor of the parallax effect.
 #[derive(Default, Component, Debug)]
 pub struct ParallaxLayer {
     pub image: &'static str,

--- a/src/components.rs
+++ b/src/components.rs
@@ -58,7 +58,7 @@ pub struct ParallaxCamera;
 /// ```
 /// 
 /// ## Note
-/// It is not necessary to provide a `TransformBundle` to the parallax layer and if you do,
+/// It is not necessary to provide a `TransformBundle` to the parallax layer but if you do,
 /// the initialisation process only takes into account the z-value as a depth offset without
 /// affecting the depth factor of the parallax effect.
 #[derive(Default, Component, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! ## `bevy_parallaxation2d`
 //! Crate providing simple 2D parallax layers in Bevy.
 //!
-//! ## Features
+//! ## In this crate:
 //! * **[`ParallaxPlugin`](crate::plugin::ParallaxPlugin)** - Plugin required for the parallax functionality.
 //! * **[`ParallaxCamera`](crate::components::ParallaxCamera)** - Component for marking the parallax camera.
 //! * **[`ParallaxLayer`](crate::components::ParallaxLayer)** - Component for creating a parallax layer.


### PR DESCRIPTION
## Description
The z offset of a transform may optionally be used to offset a parallax layer without affecting the depth factor and parallax effect.

Also improved docs somewhat.

## Motivation
I use this to ensure a correct ordering of layers in my own integration with [`bevy_ecs_ldtk`](https://github.com/Trouv/bevy_ecs_ldtk).