### PR TITLE
Duplicate images

### DIFF
--- a/examples/mountains.rs
+++ b/examples/mountains.rs
@@ -37,6 +37,13 @@ fn setup(mut commands: Commands) {
     commands.spawn_batch(vec![
         ParallaxLayer {
             image: "mountains_background.png",
+            color: Color::DARK_GRAY,
+            depth: 90.0.into(),
+            offset: Vec2::Y * 10.0,
+            flags: ParallaxFlags::OFFSET_CAMERA_TOP,
+        },
+        ParallaxLayer {
+            image: "mountains_background.png",
             depth: 84.0.into(),
             ..default()
         },

--- a/src/material.rs
+++ b/src/material.rs
@@ -41,6 +41,12 @@ impl ParallaxMaterial {
     }
 
     #[inline]
+    pub fn set_image_handle(&mut self, image: Handle<Image>) -> &mut Self {
+        self.texture = image;
+        self
+    }
+
+    #[inline]
     pub fn set_repeat_scale(&mut self, repeat_scale: Vec2) -> &mut Self {
         self.repeat_scale = repeat_scale;
         self

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -83,9 +83,10 @@ pub(crate) fn process_new_parallax_layer_data(
             .get_mut(material)
             .expect("Parallax material should be loaded");
 
-        let image = images
-            .get_mut(material.image_handle())
-            .expect("Image should be loaded");
+        let mut image = images
+            .get(material.image_handle())
+            .expect("Image should be loaded")
+            .clone();
 
         let image_dimensions = image.size_f32();
 
@@ -146,6 +147,7 @@ pub(crate) fn process_new_parallax_layer_data(
         transform.scale = scaled_image_dimensions.extend(1.0);
 
         material
+            .set_image_handle(images.add(image))
             .set_repeat_scale(scaled_image_dimensions / image_dimensions)
             .set_depth(depth_factor / scaled_image_dimensions)
             .set_offset(parallax.offset);


### PR DESCRIPTION
## Objective
Upon load, images are duplicated with the correct sampler settings from the parallax flags.

## Motivation
When spawning layers using the same image but with differing `ParallaxLayer`'s, sampler settings got overwritten.

## Solution
Create copies of the original image with the correct sampler settings. The example has an additional layer without `REPEAT_X_AXIS` to show this.
